### PR TITLE
t10 run typo

### DIFF
--- a/astral-tutorial.md
+++ b/astral-tutorial.md
@@ -244,7 +244,7 @@ java -jar astral.5.6.3.jar -q test_data/1kp.tre -i test_data/1KP-genetrees.tre -
 java -jar astral.5.6.3.jar -q test_data/1kp.tre -i test_data/1KP-genetrees.tre -t 8 -o test_data/1kp-scored-t8.tre
 ```
 ```
-java -jar astral.5.6.3.jar -q test_data/1kp.tre -i test_data/1KP-genetrees.tre -t 10 -o test_data/1kp-scored-t8.tre
+java -jar astral.5.6.3.jar -q test_data/1kp.tre -i test_data/1KP-genetrees.tre -t 10 -o test_data/1kp-scored-t10.tre
 ```
 read all the values given for a couple of branches and try to make sense of them. 
 


### PR DESCRIPTION
t10 needs to referred to, not t8 for the last example